### PR TITLE
fix: btx --test --selfservice error

### DIFF
--- a/docker/bin/burrito-test.sh
+++ b/docker/bin/burrito-test.sh
@@ -213,8 +213,8 @@ function end() {
 
 function instance_with_selfservice() {
   selfservice
-  router
   provider
+  router
   image
   secgroup
   flavor


### PR DESCRIPTION
fix: change the order of execution in instance_with_selfservice() on burrito-test.sh script